### PR TITLE
Renamed function call to new name in Trail.java

### DIFF
--- a/src/com/solarlune/bdxhelper/components/mesh/Trail.java
+++ b/src/com/solarlune/bdxhelper/components/mesh/Trail.java
@@ -73,14 +73,14 @@ public class Trail extends Component<GameObject> {
 
             vertOffsets = new HashMap<Integer, Vector3f>();
 
-            for (int i = 0; i < g.mesh().getVertexCount(materialIndex); i++)
+            for (int i = 0; i < g.mesh().vertexCount(materialIndex); i++)
                 vertOffsets.put(i, g.mesh().vertPos(materialIndex, i));
 
             vertPairs = new ArrayList<VertexCollection>();
 
             HashMap<Float, ArrayList<Integer>> vp = new HashMap<Float, ArrayList<Integer>>();
 
-            for (int i = 0; i < g.mesh().getVertexCount(materialIndex); i++) {
+            for (int i = 0; i < g.mesh().vertexCount(materialIndex); i++) {
                 float vertPos;
                 if (axis.toLowerCase().equals("x"))
                     vertPos = Math.round(g.mesh().vertPos(materialIndex, i).x * 100.0f) / 100.0f;


### PR DESCRIPTION
Changed two instances of `getVertexCount` to `vertexCount` in Trail.java as the function name has changed. Still untested as to whether this actually works though. At the very least BDX doesn't throw an error when running a game with the library.